### PR TITLE
fix: 修正 OpenAPI required 输出，解决上传 Apifox 后字段全变可选

### DIFF
--- a/src/parser/SpringControllerListener.ts
+++ b/src/parser/SpringControllerListener.ts
@@ -15,6 +15,7 @@ export class SpringControllerListener implements ParseTreeListener {
   currentMethod: any;
   comments: Map<string, string[]>; // 改为 Map 类型
   classDefinitions: { [key: string]: any }; // 存储类定义
+  schemaExtends: { [key: string]: string }; // 子类 -> 父类，供 resolveInheritance 合并继承字段
   endpoints: ApiEndpoint[];
   filePath: string;
 
@@ -33,6 +34,7 @@ export class SpringControllerListener implements ParseTreeListener {
     this.currentMethod = null;
     this.comments = new Map();
     this.classDefinitions = {}; // 存储类定义
+    this.schemaExtends = {};
     this.endpoints = [];
     this.filePath = '';
   }
@@ -211,10 +213,20 @@ export class SpringControllerListener implements ParseTreeListener {
   // 解析类定义并生成 schema
   parseClassSchema(className: string, ctx: ClassDeclarationContext) {
     if (this.openapi.hasSchema(className)) return; // 避免重复解析
+
+    // 记录继承关系（extends 父类），全部解析完后由 resolveInheritance 合并父类字段
+    if (ctx.EXTENDS?.() && ctx.typeType?.()) {
+      const superName = ctx.typeType()!.text.replace(/<.*>$/, "").replace(/\[\]$/, "");
+      if (/^[A-Za-z_]/.test(superName)) {
+        this.schemaExtends[className] = superName;
+      }
+    }
+
     const schema: {
       type: string;
       properties: { [key: string]: any };
       description: string;
+      required?: string[];
     } = {
       type: "object",
       properties: {},
@@ -273,9 +285,13 @@ export class SpringControllerListener implements ParseTreeListener {
               if (apiModelProperty.value) {
                 fieldSchema.description = apiModelProperty.value;
               }
-              if (apiModelProperty.required !== undefined) {
-                // OpenAPI 3.0 中 required 是在 schema 级别定义的
-                fieldSchema.required = apiModelProperty.required;
+              if (apiModelProperty.required) {
+                // OpenAPI 3.0 中 required 是对象 schema 级别的字段名数组，
+                // 不是属性 schema 上的布尔值。放在属性上 Apifox 会忽略，导致全部显示为可选。
+                if (!schema.required) {
+                  schema.required = [];
+                }
+                schema.required.push(fieldName);
               }
               if (apiModelProperty.example) {
                 fieldSchema.example = apiModelProperty.example;
@@ -300,12 +316,54 @@ export class SpringControllerListener implements ParseTreeListener {
             }
           }
 
+          // JSR-303/380 校验注解（@NotNull/@NotBlank/@NotEmpty）也视为必填。
+          // 很多项目不用 @ApiModelProperty(required=true) 而是用校验注解表达必填，
+          // 这里一并映射进对象级 required 数组，避免 Apifox 全部显示可选。
+          if (this.hasRequiredValidation(decl)) {
+            if (!schema.required) {
+              schema.required = [];
+            }
+            if (!schema.required.includes(fieldName)) {
+              schema.required.push(fieldName);
+            }
+          }
+
           schema.properties[fieldName] = fieldSchema;
         }
       });
 
     // 注册 schema
     this.openapi.addSchema(className, schema);
+  }
+
+  // 全部文件解析完后调用：把父类（extends）的字段和必填合并进子类 schema。
+  // 很多项目把公共字段（如签名 sign、业务线 busType，且常带 JSR-303 必填）放在 BaseCmd 等父类里，
+  // 不合并的话子类 schema 会整段丢失这些字段及其必填。子类同名字段优先。
+  resolveInheritance() {
+    const schemas = this.openapi.openapi.components.schemas;
+
+    const merge = (name: string, seen: Set<string>) => {
+      const parentName = this.schemaExtends[name];
+      if (!parentName || seen.has(name)) return;
+      seen.add(name);
+      merge(parentName, seen); // 先把祖父类并进父类，再并进子类（支持多级继承）
+
+      const child = schemas[name];
+      const parent = schemas[parentName];
+      if (!child || !parent || !parent.properties) return;
+
+      // 父字段并入子（子同名字段优先）
+      child.properties = { ...parent.properties, ...child.properties };
+
+      // 必填取并集，且只保留合并后确实存在的字段
+      if (Array.isArray(parent.required) && parent.required.length > 0) {
+        const req = new Set<string>(child.required || []);
+        parent.required.forEach((f: string) => req.add(f));
+        child.required = [...req].filter((f) => child.properties[f]);
+      }
+    };
+
+    Object.keys(this.schemaExtends).forEach((name) => merge(name, new Set()));
   }
 
   // 解析字段类型（支持嵌套对象、集合类型和枚举）
@@ -316,7 +374,6 @@ export class SpringControllerListener implements ParseTreeListener {
       items?: any;
       $ref?: string;
       enum?: any[];
-      required?: boolean;
       example?: string;
       minimum?: number;
       maximum?: number;
@@ -723,13 +780,21 @@ export class SpringControllerListener implements ParseTreeListener {
           }
         }
 
+        // 解析 @RequestParam 注解：Spring 中默认 required=true，仅当显式 required = false 时才可选。
+        // 原先只看 @ApiParam，导致没写 @ApiParam 的查询参数全部被标成可选。
+        const requestParamAnnotation = paramAnnotations?.find((a) => a.includes("RequestParam"));
+        let requestParamRequired = false;
+        if (requestParamAnnotation) {
+          requestParamRequired = !/required\s*=\s*false/.test(requestParamAnnotation);
+        }
+
         // 构建参数对象
         const paramObj: any = {
           name: paramName,
           in: paramLocation,
           schema: { type: this.mapJavaTypeToOpenAPI(paramType) },
           description: paramDescription,
-          required: paramRequired || paramLocation === "path",
+          required: paramRequired || requestParamRequired || paramLocation === "path",
         };
 
         // 添加 example
@@ -990,6 +1055,19 @@ export class SpringControllerListener implements ParseTreeListener {
     }
 
     return null;
+  }
+
+  // 字段是否带 JSR-303/380 必填校验注解（@NotNull/@NotBlank/@NotEmpty）
+  private hasRequiredValidation(decl: any): boolean {
+    const modifiers = decl.modifier?.() || [];
+    for (const mod of modifiers) {
+      const classOrInterfaceMod = mod.classOrInterfaceModifier?.();
+      const annot = classOrInterfaceMod?.annotation?.();
+      if (annot && annot.text && /^@(NotNull|NotBlank|NotEmpty)\b/.test(annot.text)) {
+        return true;
+      }
+    }
+    return false;
   }
 
   // 提取 HTTP 方法（如 @GetMapping → get）

--- a/src/parser/SpringControllerParser.ts
+++ b/src/parser/SpringControllerParser.ts
@@ -51,6 +51,8 @@ export class SpringControllerParser {
         console.error("解析失败:", file.fsPath, error);
       }
     }
+    // 所有文件解析完后再合并继承字段（父类可能在后面的文件里）
+    controllerListener.resolveInheritance();
     if(controllerListener.endpoints.length > 0){
       controllerListener.endpoints[0].schemas = openapiGenerator.openapi.components.schemas;
     }


### PR DESCRIPTION
## 问题

上传接口到 Apifox 后，请求体字段和查询参数的「是否必填」全部显示为**可选**，即使源码里声明了必填。

## 根因与修复（`SpringControllerListener` + `SpringControllerParser`）

**1. `required` 写错了 OpenAPI 位置（核心）**
`parseClassSchema` 对 `@RequestBody` DTO 字段写的是属性 schema 上的布尔值 `fieldSchema.required = true`。但 OpenAPI 3.0 的 `required` 是**对象 schema 级别的字段名数组**（`{"type":"object","required":["a","b"],...}`），属性级布尔不符合规范，Apifox 按规范读不到 → 全部可选。改为收集到对象级 `required: string[]`。

**2. `@RequestParam` 默认必填未识别**
Spring 中 `@RequestParam` 默认 `required=true`，原先只从 `@ApiParam` 取 required，没写 `@ApiParam` 的查询参数被错标为可选。现解析 `@RequestParam`，默认必填，仅 `required = false` 时可选。

**3. JSR-303 校验注解未映射为必填**
很多项目用 `@NotNull` / `@NotBlank` / `@NotEmpty` 而非 `@ApiModelProperty(required=true)` 表达必填。现把这三个注解的字段一并并入对象级 `required` 数组。

**4. `extends` 父类字段整段丢失**
DTO 继承父类（如公共基类）的字段及其必填原先完全没有被解析进 schema。新增 `resolveInheritance()`：全部文件解析完后把父类字段 + 必填合并进子类（子类同名字段优先，支持多级继承），在 `SpringControllerParser.parse()` walk 结束后调用。

另移除因第 1 点产生的孤立 `required?: boolean` 类型声明。

## 效果（before / after，以通用示例 `CreateUserRequest` 为例）

| 字段 | 修复前 | 修复后 |
|---|---|---|
| `@ApiModelProperty(required=true)` 字段 | 属性内 `required:true`（被忽略→可选） | 对象级 `required:["username","email"]` |
| `@NotBlank` 字段 | 无 required | 并入对象级 required |
| `@RequestParam String keyword` | 可选 | 必填 |
| `@RequestParam(required=false) Integer page` | 可选 | 可选（保持） |
| 继承自父类的必填字段 | 整段丢失 | 合并进子类 + 必填 |

## 测试

- `tsc -p ./` 编译通过。
- 用同一条 `SpringControllerListener` → `OpenAPIConverter` 链路对通用样例做 A/B，确认 `required` 输出符合 OpenAPI 3.0；并在一个真实的大型 Spring 项目（1000+ Java 文件）上跑通，0 解析崩溃。

注释风格沿用仓库现有中文注释。